### PR TITLE
drop the mutable default in __init__

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -7,7 +7,7 @@ __all__ = ('Crawler',)
 
 class Crawler():
 
-    def __init__(self, session: aiohttp.ClientSession, isp: list = ['dianxin', 'liantong', 'yidong'], url_to_test: str = None, test_type: str = 'http', force_resovle_ip: str = None) -> None:
+    def __init__(self, session: aiohttp.ClientSession, isp: list = None, url_to_test: str = None, test_type: str = 'http', force_resovle_ip: str = None) -> None:
         '''test url
 
         Args:
@@ -27,6 +27,8 @@ class Crawler():
             >>> Crawler(session, url_to_test = 'https://baidu.com', test_type= 'http').test()
             >>> {'url_to_test': 'https://baidu.com', 'dianxin': {'code_200_count': 32, 'un_code_200_count': 0, 'speed': [225, 271, 270, 259, 303, 322, 328, 358, 358, 395, 254, 382, 441, 421, 407, 436, 447, 471, 492, 526, 327, 394, 227, 320, 329, 1888, 2382, 3284, 3174, 6224, 4435, 7833]}, 'liantong': {'code_200_count': 31, 'un_code_200_count': 0, 'speed': [152, 202, 204, 219, 217, 240, 255, 239, 234, 267, 259, 272, 278, 299, 293, 306, 316, 308, 316, 326, 240, 386, 346, 215, 261, 324, 220, 308, 307, 352, 495]}, 'yidong': {'code_200_count': 30, 'un_code_200_count': 1, 'speed': [194, 220, 264, 239, 291, 299, 331, 336, 375, 396, 352, 408, 351, 389, 442, 530, 302, 308, 399, 363, 320, 319, 392, 492, 334, 362, 262, 310, 332, 274, 0]}}
 '''
+        if isp is None:
+            isp = []
         self.session = session
         self.isp = isp
         self.id_json = {}

--- a/platforms_to_test/base_platform.py
+++ b/platforms_to_test/base_platform.py
@@ -14,13 +14,15 @@ import json
 from upload_file_to_github import *
 import random
 class TestDomainManager:
-    def __init__(self, url_to_test, selected_domain=[]):
+    def __init__(self, url_to_test, selected_domain=None):
         """初始化测试域名管理器
         
         Args:
             url_to_test: 测试域名列表
             selected_domain: 优选域名列表，默认为空列表
         """
+        if selected_domain is None:
+            selected_domain = []
         self._url_to_test = set(url_to_test)   # 使用集合存储测试域名
         self._selected_domain = set(selected_domain)   # 使用集合存储优选域名
         


### PR DESCRIPTION
I noticed this while tracing through crawler.py. Drop the mutable default in __init__. Mutable defaults are shared across calls and usually turn into state leaks. I kept the patch small and re-ran syntax checks after applying it.